### PR TITLE
Fix GPS coordinate parsing

### DIFF
--- a/photonix/photos/utils/metadata.py
+++ b/photonix/photos/utils/metadata.py
@@ -54,15 +54,17 @@ def parse_datetime(date_str):
 
 def parse_gps_location(gps_str):
     # 50 deg 49' 9.53" N, 0 deg 8' 13.33" W
-    regex = r'''(\d{1,3}) deg (\d{1,2})' (\d{1,2}).(\d{2})" ([N,S]), (\d{1,3}) deg (\d{1,2})' (\d{1,2}).(\d{2})" ([E,W])'''
+    regex = r"""(\d{1,3}) deg (\d{1,2})' (\d{1,2}(?:\.\d+)?)\" ([NS]), (\d{1,3}) deg (\d{1,2})' (\d{1,2}(?:\.\d+)?)\" ([EW])"""
     m = re.search(regex, gps_str)
+    if not m:
+        return (None, None)
 
-    latitude = float(m.group(1)) + (float(m.group(2)) / 60) + (float('{}.{}'.format(m.group(3), m.group(4))) / 60 / 100)
-    if m.group(5) == 'S':
+    latitude = float(m.group(1)) + (float(m.group(2)) / 60) + (float(m.group(3)) / 3600)
+    if m.group(4) == 'S':
         latitude *= -1
 
-    longitude = float(m.group(6)) + (float(m.group(7)) / 60) + (float('{}.{}'.format(m.group(8), m.group(9))) / 60 / 100)
-    if m.group(10) == 'W':
+    longitude = float(m.group(5)) + (float(m.group(6)) / 60) + (float(m.group(7)) / 3600)
+    if m.group(8) == 'W':
         longitude *= -1
 
     return (latitude, longitude)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -23,8 +23,8 @@ def test_location():
     # Conversion from GPS exif data to latitude/longitude
     gps_position = '64 deg 9\' 0.70" N, 21 deg 56\' 3.47" W'
     latitude, longitude = parse_gps_location(gps_position)
-    assert latitude == 64.15011666666668
-    assert longitude == -21.933911666666667
+    assert round(latitude, 9) == 64.150194444
+    assert round(longitude, 9) == -21.934297222
 
 
 def test_datetime():


### PR DESCRIPTION
## Summary
- handle decimal seconds correctly in parse_gps_location
- make test expectations match the correct conversion

## Testing
- `python test.py tests/test_metadata.py::test_location -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_684184be7ff0832e9afbfbcc96f885b7