### PR TITLE
Update docstring for task progress

### DIFF
--- a/photonix/photos/schema.py
+++ b/photonix/photos/schema.py
@@ -525,7 +525,7 @@ class Query(graphene.ObjectType):
 
     @login_required
     def resolve_task_progress(self, info, **kwargs):
-        """Return No. of remaining and total tasks with there diffrent types."""
+        """Return the number of remaining and total tasks with their different types."""
         return {
             "generate_thumbnails": count_remaining_task('generate_thumbnails'),
             "process_raw": count_remaining_task('process_raw'),


### PR DESCRIPTION
## Summary
- clarify docstring wording for GraphQL task progress resolver

## Testing
- `pytest -q tests/test_graphql.py::TestLibrary::test_something` *(fails: required field "lineno" missing from alias)*

------
https://chatgpt.com/codex/tasks/task_e_6841883e9d48832ea5bb8468d261e49e