### PR TITLE
Fix typo in test comment

### DIFF
--- a/tests/test_task_queue.py
+++ b/tests/test_task_queue.py
@@ -60,7 +60,7 @@ def test_tasks_created_updated(photo_fixture_snow):
     assert (timezone.now() - task.started_at).seconds < 10
     assert (timezone.now() - task.finished_at).seconds < 1
 
-    # Chekc next task has been added to classify images
+    # Check next task has been added to classify images
     task = Task.objects.get(type='classify_images', subject_id=photo_fixture_snow.id)
     assert task.status == 'P'
     assert (timezone.now() - task.created_at).seconds < 1


### PR DESCRIPTION
## Summary
- update comment in `tests/test_task_queue.py`

## Testing
- `pytest tests/test_task_queue.py::test_tasks_created_updated -q` *(fails: Error 111 connecting to 127.0.0.1:6379)*

------
https://chatgpt.com/codex/tasks/task_e_684188274974832e96a32fee4543f9ef