### PR TITLE
Fix has_photo_files property and test

### DIFF
--- a/photonix/photos/models.py
+++ b/photonix/photos/models.py
@@ -188,7 +188,7 @@ class Photo(UUIDModel, VersionedModel):
 
     @property
     def has_photo_files(self):
-        return self.files.all().count() == 0
+        return self.files.exists()
 
     def clear_tags(self, source, type):
         self.photo_tags.filter(tag__source=source, tag__type=type).delete()

--- a/tests/test_photo_model.py
+++ b/tests/test_photo_model.py
@@ -1,0 +1,12 @@
+import pytest
+
+from .factories import PhotoFactory, PhotoFileFactory
+
+@pytest.mark.django_db
+def test_has_photo_files_property():
+    photo = PhotoFactory()
+    assert photo.has_photo_files is False
+
+    PhotoFileFactory(photo=photo)
+    photo.refresh_from_db()
+    assert photo.has_photo_files is True


### PR DESCRIPTION
## Summary
- fix boolean logic for `Photo.has_photo_files`
- add a small model test for `has_photo_files`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684184bf4d28832ea74397beede651fd