### PR TITLE
Update Docker Compose for modern engines

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,9 +1,9 @@
-version: '3'
+version: '3.9'
 
 services:
   postgres:
     container_name: photonix-postgres
-    image: postgres:11.1-alpine
+    image: postgres:16-alpine
     ports:
       - '5432:5432'
     environment:
@@ -14,7 +14,7 @@ services:
 
   redis:
     container_name: photonix-redis
-    image: redis:6.2.2
+    image: redis:7-alpine
     ports:
       - '6379:6379'
 
@@ -59,6 +59,6 @@ services:
       - ../data/cache:/data/cache
       - ../data/models:/data/models
       - ../system/supervisord.conf:/etc/supervisord.conf
-    links:
+    depends_on:
       - postgres
       - redis

--- a/docker/docker-compose.example.yml
+++ b/docker/docker-compose.example.yml
@@ -1,9 +1,9 @@
-version: '3'
+version: '3.9'
 
 services:
   postgres:
     container_name: photonix-postgres
-    image: postgres:11.1-alpine
+    image: postgres:16-alpine
     environment:
       POSTGRES_DB: photonix
       POSTGRES_PASSWORD: password
@@ -12,11 +12,14 @@ services:
 
   redis:
     container_name: photonix-redis
-    image: redis:6.2.2
+    image: redis:7-alpine
 
   photonix:
     container_name: photonix
     image: photonixapp/photonix:latest
+    depends_on:
+      - postgres
+      - redis
     ports:
       - '8888:80'
     environment:
@@ -33,6 +36,3 @@ services:
       - ./data/raw-photos-processed:/data/raw-photos-processed
       - ./data/cache:/data/cache
       - ./data/models:/data/models
-    links:
-      - postgres
-      - redis

--- a/docker/docker-compose.prd.yml
+++ b/docker/docker-compose.prd.yml
@@ -1,9 +1,9 @@
-version: '3'
+version: '3.9'
 
 services:
   postgres:
     container_name: photonix-postgres
-    image: postgres:11.1-alpine
+    image: postgres:16-alpine
     ports:
       - '5432:5432'
     environment:
@@ -14,7 +14,7 @@ services:
 
   redis:
     container_name: photonix-redis
-    image: redis:6.2.2
+    image: redis:7-alpine
     ports:
       - '6379:6379'
 
@@ -40,6 +40,6 @@ services:
       - ../data/raw-photos-processed:/data/raw-photos-processed
       - ../data/cache:/data/cache
       - ../data/models:/data/models
-    links:
+    depends_on:
       - postgres
       - redis


### PR DESCRIPTION
## Summary
- update example, dev, and production compose files to latest version syntax
- switch postgres and redis containers to current images
- remove deprecated `links` usage and use `depends_on`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6841970961f0832e8df1a3a55cc3ee45